### PR TITLE
KAS-3295 Refactor agendaitem predicates

### DIFF
--- a/support/sparql-queries.js
+++ b/support/sparql-queries.js
@@ -227,7 +227,7 @@ async function getAgendaitemsWithNewsletterInfo(kaleidosAgenda) {
     PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
     PREFIX schema: <http://schema.org/>
 
-    SELECT ?agendaitem AS ?uri ?number ?title ?alternative ?isAnnouncement ?previousAgendaitem ?newsletterInfo
+    SELECT ?agendaitem AS ?uri ?number ?title ?shortTitle ?isAnnouncement ?previousAgendaitem ?newsletterInfo
     WHERE {
       GRAPH ${sparqlEscapeUri(config.kaleidos.graphs.kanselarij)} {
         <${kaleidosAgenda.uri}> dct:hasPart ?agendaitem .
@@ -236,7 +236,7 @@ async function getAgendaitemsWithNewsletterInfo(kaleidosAgenda) {
                              prov:generated ?newsletterInfo .
         ?newsletterInfo ext:inNieuwsbrief "true"^^<http://mu.semte.ch/vocabularies/typed-literals/boolean> .
         OPTIONAL { ?agendaitem dct:title ?title . }
-        OPTIONAL { ?agendaitem besluitvorming:korteTitel ?alternative . }
+        OPTIONAL { ?agendaitem besluitvorming:korteTitel ?shortTitle . }
         OPTIONAL { ?agendaitem ext:wordtGetoondAlsMededeling ?isAnnouncement . }
         OPTIONAL { ?agendaitem besluit:aangebrachtNa ?previousAgendaitem . }
         OPTIONAL { ?newsletterInfo ext:afgewerkt ?afgewerkt . }
@@ -260,8 +260,8 @@ async function insertPublicAgendaitems(kaleidosAgendaitems, publicAgenda, public
     const optionalStatements = [];
     if (agendaitem.title)
       optionalStatements.push(`<${agendaitem.publicUri}> dct:title ${sparqlEscapeString(agendaitem.title)} .`);
-    if (agendaitem.alternative)
-      optionalStatements.push(`<${agendaitem.publicUri}> besluitvorming:korteTitel ${sparqlEscapeString(agendaitem.alternative)} .`);
+    if (agendaitem.shortTitle)
+      optionalStatements.push(`<${agendaitem.publicUri}> besluitvorming:korteTitel ${sparqlEscapeString(agendaitem.shortTitle)} .`);
     if (agendaitem.previousAgendaitem) {
       const previousAgendaitem = kaleidosAgendaitems.find(item => agendaitem.previousAgendaitem == item.uri);
       if (previousAgendaitem)
@@ -317,7 +317,7 @@ async function insertPublicAgendaitems(kaleidosAgendaitems, publicAgenda, public
       newsletterInfo: agendaitem.newsletterInfo,
       number: agendaitem.number,
       type: agendaitem.type,
-      shortTitle: agendaitem.alternative,
+      shortTitle: agendaitem.shortTitle,
       title: agendaitem.title
     });
   }

--- a/support/sparql-queries.js
+++ b/support/sparql-queries.js
@@ -225,12 +225,13 @@ async function getAgendaitemsWithNewsletterInfo(kaleidosAgenda) {
     PREFIX besluitvorming: <http://data.vlaanderen.be/ns/besluitvorming#>
     PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
     PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+    PREFIX schema: <http://schema.org/>
 
     SELECT ?agendaitem AS ?uri ?number ?title ?alternative ?isAnnouncement ?previousAgendaitem ?newsletterInfo
     WHERE {
       GRAPH ${sparqlEscapeUri(config.kaleidos.graphs.kanselarij)} {
         <${kaleidosAgenda.uri}> dct:hasPart ?agendaitem .
-        ?agendaitem ext:prioriteit ?number .
+        ?agendaitem schema:position ?number .
         ?agendaitemTreatment besluitvorming:heeftOnderwerp ?agendaitem ;
                              prov:generated ?newsletterInfo .
         ?newsletterInfo ext:inNieuwsbrief "true"^^<http://mu.semte.ch/vocabularies/typed-literals/boolean> .

--- a/support/sparql-queries.js
+++ b/support/sparql-queries.js
@@ -235,7 +235,7 @@ async function getAgendaitemsWithNewsletterInfo(kaleidosAgenda) {
                              prov:generated ?newsletterInfo .
         ?newsletterInfo ext:inNieuwsbrief "true"^^<http://mu.semte.ch/vocabularies/typed-literals/boolean> .
         OPTIONAL { ?agendaitem dct:title ?title . }
-        OPTIONAL { ?agendaitem dct:alternative ?alternative . }
+        OPTIONAL { ?agendaitem besluitvorming:korteTitel ?alternative . }
         OPTIONAL { ?agendaitem ext:wordtGetoondAlsMededeling ?isAnnouncement . }
         OPTIONAL { ?agendaitem besluit:aangebrachtNa ?previousAgendaitem . }
         OPTIONAL { ?newsletterInfo ext:afgewerkt ?afgewerkt . }


### PR DESCRIPTION
Backend PR: https://github.com/kanselarij-vlaanderen/app-kaleidos/pull/267

There's another use of `dct:alternative` on line 401, but if I understood the service correctly that one is for news items, so I left it as is.