### PR TITLE
KAS-3360 Piece no longer has a confidential property

### DIFF
--- a/support/sparql-queries.js
+++ b/support/sparql-queries.js
@@ -443,8 +443,6 @@ async function getPublicDocuments(kaleidosNewsitem, kaleidosAgendaitem) {
         ?agendaActivity besluitvorming:genereertAgendapunt <${kaleidosAgendaitem}> .
         <${kaleidosAgendaitem}> besluitvorming:geagendeerdStuk ?piece .
         ?piece ext:toegangsniveauVoorDocumentVersie <${config.kaleidos.accessLevels.public}> .
-        OPTIONAL { ?piece ext:vertrouwelijk ?confidential . }
-        FILTER(?confidential != "true"^^mulit:boolean )
       }
     }
   `));


### PR DESCRIPTION
Backend PR: https://github.com/kanselarij-vlaanderen/app-kaleidos/pull/275

Pieces no longer have confidentiality, so we remove said filtering here.