### PR TITLE
KAS-2325: Use Themis document type URIs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "themis-export-service",
-  "version": "3.0.0",
+  "version": "2.1.0",
   "description": "Microservice that exports data from Kaleidos to be published on Themis",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "themis-export-service",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "description": "Microservice that exports data from Kaleidos to be published on Themis",
   "repository": {
     "type": "git",

--- a/support/sparql-queries.js
+++ b/support/sparql-queries.js
@@ -519,7 +519,6 @@ async function insertDocuments(kaleidosPieces, agendaitem, graph) {
     await copyToLocalGraph(`
     PREFIX dct: <http://purl.org/dc/terms/>
     PREFIX dossier: <https://data.vlaanderen.be/ns/dossier#>
-    PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
 
     CONSTRUCT {
       ?documentContainer dct:type ?documentType .
@@ -528,7 +527,7 @@ async function insertDocuments(kaleidosPieces, agendaitem, graph) {
       GRAPH ${sparqlEscapeUri(config.kaleidos.graphs.kanselarij)} {
         ?documentContainer a dossier:Serie ;
           dossier:collectie.bestaatUit ${sparqlEscapeUri(piece.uri)} ;
-          ext:documentType ?documentType .
+          dct:type ?documentType .
       }
     }`, graph);
 


### PR DESCRIPTION
Replaces the single usage of `ext:documentType` with `dct:type`. Needs a bump of `app-themis-export`, PR will be linked when created.

Bumped the version to `3.0.0` because I need a new version to open the `app-themis-export` PR and I *think* changing a predicate would constitute a breaking change, but not sure. Version can be changed before merging in any case.

:warning: Note: I didn't run this code given that it's a tiny change and setting up `app-themis-export` seems like quite a bit of hassle.

Related PRs:
- [x] https://github.com/kanselarij-vlaanderen/app-themis-export/pull/2