### PR TITLE
KAS-3983: Retry failed PublicExportJobs

### DIFF
--- a/app.js
+++ b/app.js
@@ -145,14 +145,20 @@ async function triggerKaleidosPublications() {
 
 async function retriggerFailedExportJobs() {
   const failedJobs = await getFailedJobs();
-  console.debug(failedJobs);
-  for (let job of failedJobs) {
-    if (job.retryCount < config.export.job.maxRetryCount) {
-      console.log(
-        `Retrying failed job <${job.uri}>... [${job.retryCount + 1}/${config.export.job.maxRetryCount}]`
-      );
-      await incrementJobRetryCount(job.uri, job.retryCount);
-      await executeJob(job);
+  if (failedJobs.length) {
+    console.log(`Found {failedJobs.length} failed jobs to retry`);
+    for (let job of failedJobs) {
+      if (job.retryCount < config.export.job.maxRetryCount) {
+        console.log(
+          `Retrying failed job <${job.uri}>... [${job.retryCount + 1}/${config.export.job.maxRetryCount}]`
+        );
+        await incrementJobRetryCount(job.uri, job.retryCount);
+        await executeJob(job);
+      } else {
+        console.log(
+          `Skipping failed job <${job.uri}> because max retry count was reached [${job.retryCount}/${config.export.job.maxRetryCount}]`
+        );
+      }
     }
   }
 }

--- a/app.js
+++ b/app.js
@@ -1,9 +1,18 @@
 import { app, errorHandler } from 'mu';
 import fetch from 'node-fetch';
 import { CronJob } from 'cron';
-import { createJob, getNextScheduledJob, getJob, executeJob, getSummary } from './support/jobs';
+import {
+  createJob,
+  getNextScheduledJob,
+  getJob,
+  executeJob,
+  getSummary,
+  getFailedJobs,
+  incrementJobRetryCount,
+} from './support/jobs';
 import { fetchScheduledPublicationActivities } from './support/polling';
 import sq from './support/sparql-queries';
+import config from './config';
 
 /** Schedule publications from Kaleidos cron job */
 const cronFrequency = process.env.PUBLICATION_CRON_PATTERN || '0 * * * * *';
@@ -11,6 +20,8 @@ const cronFrequency = process.env.PUBLICATION_CRON_PATTERN || '0 * * * * *';
 new CronJob(cronFrequency, function() {
   console.log(`Kaleidos publication polling triggered by cron job at ${new Date().toISOString()}`);
   triggerKaleidosPublications();
+  console.log(`Retrying failed PublicExportJobs triggered by cron job at ${new Date().toISOString()}`);
+  retriggerFailedExportJobs();
 }, null, true);
 
 /**
@@ -129,5 +140,19 @@ async function triggerKaleidosPublications() {
     }
   } else {
     console.log(`Nothing to publish right now.`);
+  }
+}
+
+async function retriggerFailedExportJobs() {
+  const failedJobs = await getFailedJobs();
+  console.debug(failedJobs);
+  for (let job of failedJobs) {
+    if (job.retryCount < config.export.job.maxRetryCount) {
+      console.log(
+        `Retrying failed job <${job.uri}>... [${job.retryCount + 1}/${config.export.job.maxRetryCount}]`
+      );
+      await incrementJobRetryCount(job.uri, job.retryCount);
+      await executeJob(job);
+    }
   }
 }

--- a/config.js
+++ b/config.js
@@ -26,7 +26,8 @@ export default {
         ongoing: 'http://data.kaleidos.vlaanderen.be/public-export-job-statuses/ongoing',
         success: 'http://data.kaleidos.vlaanderen.be/public-export-job-statuses/success',
         failure: 'http://data.kaleidos.vlaanderen.be/public-export-job-statuses/failure'
-      }
+      },
+      maxRetryCount: 5,
     },
     resourceUri: {
       public: function(type, id) { return `http://themis.vlaanderen.be/id/${type}/${id}`; }


### PR DESCRIPTION
Before we "silently" failed exports if e.g. Virtuoso's checkpointing caused our queries to fail. These failed jobs hung around in our database but we never did anything with them. We suspect that some of the users' complaints about publications not reaching Valvas was due to this. Our first step towards fixing that is to ensure that we retry failed jobs up to 5 times.

Further steps will be taken to alleviate the process, by making the status of the export jobs more explicit so that users can track it.