### PR TITLE
Feature/kas 4301 dont allow parallel executions

### DIFF
--- a/.woodpecker/.feature.yml
+++ b/.woodpecker/.feature.yml
@@ -5,6 +5,6 @@ pipeline:
       repo: "${CI_REPO_OWNER%%-vlaanderen}/${CI_REPO_NAME}"
       tags: "feature-${CI_COMMIT_BRANCH##feature/}"
     secrets: [docker_username, docker_password]
-    when:
-      event: push
-      branch: feature/*
+when:
+  event: push
+  branch: feature/*

--- a/.woodpecker/.latest.yml
+++ b/.woodpecker/.latest.yml
@@ -5,6 +5,6 @@ pipeline:
       repo: "${CI_REPO_OWNER%%-vlaanderen}/${CI_REPO_NAME}"
       tags: latest
     secrets: [docker_username, docker_password]
-    when:
-      event: push
-      branch: [master, main]
+when:
+  event: push
+  branch: [master, main]

--- a/.woodpecker/.release.yml
+++ b/.woodpecker/.release.yml
@@ -5,6 +5,6 @@ pipeline:
       repo: "${CI_REPO_OWNER%%-vlaanderen}/${CI_REPO_NAME}"
       tags: "${CI_COMMIT_TAG##v}"
     secrets: [ docker_username, docker_password ]
-    when:
-      event: tag
-      tag: v*
+when:
+  event: tag
+  tag: v*

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The following environment variables can be configured:
 | ext    | http://mu.semte.ch/vocabularies/ext |
 
 #### Public export job
-Resource representing an export job. Jobs are executed one by one using the FIFO approach.
+Resource representing an export job. Jobs are executed one by one using the FIFO approach. When an export job fails, it will be retried up to 5 times before being permanently marked as a failed job.
 ##### Class
 `ext:PublicExportJob`
 ##### Properties

--- a/app.js
+++ b/app.js
@@ -16,8 +16,6 @@ const cronFrequency = process.env.PUBLICATION_CRON_PATTERN || '0 * * * * *';
 new CronJob(cronFrequency, function() {
   console.log(`Kaleidos publication polling triggered by cron job at ${new Date().toISOString()}`);
   triggerKaleidosPublications();
-  console.log(`Retrying failed PublicExportJobs triggered by cron job at ${new Date().toISOString()}`);
-  retriggerFailedExportJobs();
 }, null, true);
 
 const jobManager = new JobManager();
@@ -128,25 +126,5 @@ async function triggerKaleidosPublications() {
     }
   } else {
     console.log(`Nothing to publish right now.`);
-  }
-}
-
-async function retriggerFailedExportJobs() {
-  const failedJobs = await getFailedJobs();
-  if (failedJobs.length) {
-    console.log(`Found {failedJobs.length} failed jobs to retry`);
-    for (let job of failedJobs) {
-      if (job.retryCount < config.export.job.maxRetryCount) {
-        console.log(
-          `Retrying failed job <${job.uri}>... [${job.retryCount + 1}/${config.export.job.maxRetryCount}]`
-        );
-        await incrementJobRetryCount(job.uri, job.retryCount);
-        await executeJob(job);
-      } else {
-        console.log(
-          `Skipping failed job <${job.uri}> because max retry count was reached [${job.retryCount}/${config.export.job.maxRetryCount}]`
-        );
-      }
-    }
   }
 }

--- a/support/jobs.js
+++ b/support/jobs.js
@@ -16,7 +16,7 @@ class JobManager {
     let hasRun = false;
     try {
       this.isExecuting = true;
-      const job = await getNextScheduledJob()
+      const job = await getNextScheduledJob();
       if (job) {
         console.debug(`Found next scheduled job <${job.uri}>, executing...`);
         await executeJob(job);
@@ -257,9 +257,6 @@ async function incrementJobRetryCount(uri, retryCount) {
 export {
   JobManager,
   createJob,
-  getNextScheduledJob,
   getJob,
-  executeJob,
   getSummary,
-  incrementJobRetryCount,
 };

--- a/support/jobs.js
+++ b/support/jobs.js
@@ -50,6 +50,7 @@ async function createJob(meeting, scopes, source = null) {
 
   const now = new Date();
 
+  console.log(`Creating job with uri ${sparqlEscapeUri(jobUri)} for meeting ${sparqlEscapeUri(meeting)}`);
   await update(`
   PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
   PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>


### PR DESCRIPTION
This PR adds a `JobManager` class that runs the export jobs (which used to be done by the `executeJobs` function) and holds an `isExecuting` flag to ensure we never run multiple jobs at the same time. It also replaces the "retry mechanism" which used to run at a different interval as the regular scheduled jobs, instead failed jobs are now re-run until we exhaust the retries and leave them as totally failed jobs (or they succeed)

https://kanselarij.atlassian.net/browse/KAS-4301

**Note:** in the ticket we specify that the `JobManager` should be a Singleton. True Singletons in Javascript (where only one instance can ever exist and they can't be tampered with) are somewhat annoying to implement. The current implementation of the `JobManager` is just a regular class, so care should be taken not to instantiate it more than once.