### PR TITLE
chore: tweak the query to fetch unpublished activities

### DIFF
--- a/support/polling.js
+++ b/support/polling.js
@@ -1,3 +1,4 @@
+import { querySudo as query } from '@lblod/mu-auth-sudo';
 import { sparqlEscapeUri, sparqlEscapeDateTime } from 'mu';
 import { parseResult } from './query-helpers';
 import config from '../config.js';

--- a/support/polling.js
+++ b/support/polling.js
@@ -1,4 +1,3 @@
-import { querySudo as query } from '@lblod/mu-auth-sudo';
 import { sparqlEscapeUri, sparqlEscapeDateTime } from 'mu';
 import { queryVirtuoso } from './virtuoso';
 import { parseResult } from './query-helpers';
@@ -12,30 +11,10 @@ async function fetchScheduledPublicationActivities() {
   const publicationActivities = await getRecentPublicationActivities();
   const unpublishedActivities = [];
   for (let publicationActivity of publicationActivities) {
-    const isPublished = await hasBeenPublished(publicationActivity.uri);
-    if (!isPublished) {
-      publicationActivity.scope = await getScope(publicationActivity.uri);
-      unpublishedActivities.push(publicationActivity);
-    }
+    publicationActivity.scope = await getScope(publicationActivity.uri);
+    unpublishedActivities.push(publicationActivity);
   }
   return unpublishedActivities;
-}
-
-async function hasBeenPublished(publicationActivity) {
-  const jobs = parseResult(await query(`
-      PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
-      PREFIX dct: <http://purl.org/dc/terms/>
-
-      SELECT ?uri
-      WHERE {
-        GRAPH <${config.export.graphs.job}> {
-          ?uri a ext:PublicExportJob ;
-            dct:source ${sparqlEscapeUri(publicationActivity)} .
-        }
-      } LIMIT 1
-    `));
-
-  return jobs.length != 0;
 }
 
 /**
@@ -51,6 +30,7 @@ async function getRecentPublicationActivities() {
     PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
     PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
     PREFIX adms: <http://www.w3.org/ns/adms#>
+    PREFIX dct: <http://purl.org/dc/terms/>
 
     SELECT ?uri ?meeting ?meetingId ?plannedStart
     WHERE {
@@ -63,6 +43,9 @@ async function getRecentPublicationActivities() {
         FILTER(?plannedStart >= ${sparqlEscapeDateTime(publicationWindowStart)})
         FILTER(?plannedStart <= ${sparqlEscapeDateTime(now)})
         ?meeting mu:uuid ?meetingId .
+      }
+      GRAPH ${sparqlEscapeUri(config.export.graphs.job)} {
+        FILTER NOT EXISTS { ?job a ext:PublicExportJob ; dct:source ?uri }
       }
     } ORDER BY ?plannedStart
   `);


### PR DESCRIPTION
No JIRA ticket, just something I noticed, so not necessary to merge either.

In the polling query we fetch all publication activities and then for each activity we verify if it has already been published (or rather, if there exists a job for said activity). This is presumably a remnant of the separate Kaleidos & Themis export databases.
Since all data now exists in one database, we can make the initial query filter out the activities that have a job, this way we save on the extra calls.