### PR TITLE
Feature/kas 4094 general improvements

### DIFF
--- a/support/graph-helpers.js
+++ b/support/graph-helpers.js
@@ -4,6 +4,7 @@ import { sparqlEscapeUri } from 'mu';
 // All intermediate data is written directly to Virtuoso in order to not generate delta notifications for these data insertions
 // Virtuoso is just used here as a temporary store to gather data before writing it to a file
 import { queryVirtuoso as query } from './virtuoso';
+import { querySudo } from '@lblod/mu-auth-sudo';
 import config from '../config';
 
 const batchSize = parseInt(process.env.EXPORT_BATCH_SIZE) || 1000;
@@ -51,7 +52,7 @@ async function writeToFile(graph, file, targetGraph = config.export.graphs.publi
 }
 
 async function countTriples(graph) {
-  const queryResult = await query(`
+  const queryResult = await querySudo(`
       SELECT (COUNT(*) as ?count)
       WHERE {
         GRAPH ${sparqlEscapeUri(graph)} {

--- a/support/graph-helpers.js
+++ b/support/graph-helpers.js
@@ -30,11 +30,12 @@ async function writeToFile(graph, file, targetGraph = config.export.graphs.publi
         ?s ?p ?o
       }
       WHERE {
-        GRAPH ${sparqlEscapeUri(graph)} {
-          ?s ?p ?o .
-        }
+        { SELECT ?s ?p ?o WHERE {
+            GRAPH ${sparqlEscapeUri(graph)} {
+              ?s ?p ?o .
+            }
+          } ORDER BY ?s LIMIT ${batchSize} OFFSET %OFFSET }
       }
-      LIMIT ${batchSize} OFFSET %OFFSET
     `;
 
     while (offset < count) {

--- a/support/graph-helpers.js
+++ b/support/graph-helpers.js
@@ -3,8 +3,8 @@ import request from 'request';
 import { sparqlEscapeUri } from 'mu';
 // All intermediate data is written directly to Virtuoso in order to not generate delta notifications for these data insertions
 // Virtuoso is just used here as a temporary store to gather data before writing it to a file
-import { queryVirtuoso as query } from './virtuoso';
 import { querySudo } from '@lblod/mu-auth-sudo';
+import { queryVirtuoso } from './virtuoso';
 import config from '../config';
 
 const batchSize = parseInt(process.env.EXPORT_BATCH_SIZE) || 1000;
@@ -95,11 +95,11 @@ async function appendBatch(file, query, offset = 0) {
 }
 
 async function add(source, target) {
-  await query(`ADD SILENT GRAPH <${source}> TO <${target}>`);
+  await queryVirtuoso(`ADD SILENT GRAPH <${source}> TO <${target}>`);
 }
 
 async function clean(graph) {
-  await query(`DROP SILENT GRAPH <${graph}>`);
+  await queryVirtuoso(`DEFINE sql:log-enable 3 DROP SILENT GRAPH <${graph}>`);
 }
 
 export {

--- a/support/polling.js
+++ b/support/polling.js
@@ -1,6 +1,5 @@
 import { querySudo as query } from '@lblod/mu-auth-sudo';
 import { sparqlEscapeUri, sparqlEscapeDateTime } from 'mu';
-import { queryVirtuoso } from './virtuoso';
 import { parseResult } from './query-helpers';
 import config from '../config.js';
 
@@ -46,7 +45,7 @@ async function getRecentPublicationActivities() {
   const now = new Date();
   const publicationWindowStart = new Date(now.getTime() - config.kaleidos.publication.window);
 
-  const result = await queryVirtuoso(`
+  const result = await query(`
     PREFIX prov: <http://www.w3.org/ns/prov#>
     PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
     PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
@@ -82,7 +81,7 @@ async function getRecentPublicationActivities() {
 }
 
 async function getScope(publicationActivity) {
-  const scope = parseResult(await queryVirtuoso(`
+  const scope = parseResult(await query(`
     PREFIX prov: <http://www.w3.org/ns/prov#>
     PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
     SELECT ?label

--- a/support/sparql-queries.js
+++ b/support/sparql-queries.js
@@ -1,7 +1,8 @@
 import { uuid, sparqlEscapeString, sparqlEscapeUri, sparqlEscapeDateTime, sparqlEscapeInt } from 'mu';
 // All intermediate data is written directly to Virtuoso in order to not generate delta notifications for these data insertions
 // Virtuoso is just used here as a temporary store to gather data before writing it to a file
-import { queryVirtuoso as query, updateVirtuoso as update } from './virtuoso';
+import { querySudo } from '@lblod/mu-auth-sudo';
+import { updateVirtuoso } from './virtuoso';
 import { parseResult, copyToLocalGraph } from './query-helpers';
 import config from '../config.js';
 
@@ -12,7 +13,7 @@ async function getMeeting({ uri, id }) {
   } else {
     subjectStatement = `?uri mu:uuid ${sparqlEscapeString(id)} .`;
   }
-  const sessions = parseResult(await query(`
+  const sessions = parseResult(await querySudo(`
     PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
     PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
     PREFIX prov: <http://www.w3.org/ns/prov#>
@@ -100,7 +101,7 @@ async function insertPublicationActivity(meeting, graph) {
   const activity = config.export.resourceUri.public('publicatie-activiteit', id);
   const now = new Date();
 
-  await update(`
+  await updateVirtuoso(`
     PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
     PREFIX prov: <http://www.w3.org/ns/prov#>
     PREFIX dct: <http://purl.org/dc/terms/>
@@ -123,7 +124,7 @@ async function insertPublicationActivity(meeting, graph) {
 }
 
 async function getPreviousPublicationActivity(meeting) {
-  const publications = parseResult(await query(`
+  const publications = parseResult(await querySudo(`
     PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
     PREFIX prov: <http://www.w3.org/ns/prov#>
     PREFIX dct: <http://purl.org/dc/terms/>
@@ -142,7 +143,7 @@ async function getPreviousPublicationActivity(meeting) {
 }
 
 async function getLatestAgendaOfMeeting(meeting) {
-  let agendas = parseResult(await query(`
+  let agendas = parseResult(await querySudo(`
     PREFIX besluitvorming: <https://data.vlaanderen.be/ns/besluitvorming#>
     PREFIX dct: <http://purl.org/dc/terms/>
 
@@ -155,7 +156,7 @@ async function getLatestAgendaOfMeeting(meeting) {
 
   if (!agendas.length) {
     console.log(`No agenda found. Trying pre-Kaleidos query to retrieve agenda for meeting <${meeting}>`);
-    agendas = parseResult(await query(`
+    agendas = parseResult(await querySudo(`
     PREFIX besluitvorming: <https://data.vlaanderen.be/ns/besluitvorming#>
     PREFIX dct: <http://purl.org/dc/terms/>
     PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
@@ -175,7 +176,7 @@ async function insertPublicAgenda(kaleidosAgenda, meeting, publication, previous
   const title = kaleidosAgenda.title ? `Publieke ${kaleidosAgenda.title}` : 'Publieke agenda';
   const now = new Date();
 
-  await update(`
+  await updateVirtuoso(`
     PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
     PREFIX prov: <http://www.w3.org/ns/prov#>
     PREFIX dct: <http://purl.org/dc/terms/>
@@ -197,7 +198,7 @@ async function insertPublicAgenda(kaleidosAgenda, meeting, publication, previous
   `);
 
   if (previousPublication) {
-    await update(`
+    await updateVirtuoso(`
       PREFIX prov: <http://www.w3.org/ns/prov#>
       PREFIX besluitvorming: <https://data.vlaanderen.be/ns/besluitvorming#>
 
@@ -221,7 +222,7 @@ async function insertPublicAgenda(kaleidosAgenda, meeting, publication, previous
 }
 
 async function getAgendaitemsWithNewsletterInfo(kaleidosAgenda) {
-  return parseResult(await query(`
+  return parseResult(await querySudo(`
     PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
     PREFIX prov: <http://www.w3.org/ns/prov#>
     PREFIX dct: <http://purl.org/dc/terms/>
@@ -230,7 +231,7 @@ async function getAgendaitemsWithNewsletterInfo(kaleidosAgenda) {
     PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
     PREFIX schema: <http://schema.org/>
 
-    SELECT ?agendaitem AS ?uri ?number ?title ?shortTitle ?type ?previousAgendaitem ?newsletterInfo
+    SELECT (?agendaitem AS ?uri) ?number ?title ?shortTitle ?type ?previousAgendaitem ?newsletterInfo
     WHERE {
       GRAPH ${sparqlEscapeUri(config.kaleidos.graphs.kanselarij)} {
         <${kaleidosAgenda.uri}> dct:hasPart ?agendaitem .
@@ -269,7 +270,7 @@ async function insertPublicAgendaitems(kaleidosAgendaitems, publicAgenda, public
         optionalStatements.push(`<${agendaitem.publicUri}> besluit:aangebrachtNa ${sparqlEscapeUri(previousAgendaitem.publicUri)} .`);
     }
 
-    await update(`
+    await updateVirtuoso(`
       PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
       PREFIX prov: <http://www.w3.org/ns/prov#>
       PREFIX dct: <http://purl.org/dc/terms/>
@@ -293,7 +294,7 @@ async function insertPublicAgendaitems(kaleidosAgendaitems, publicAgenda, public
       }`);
 
     if (previousPublication) {
-      await update(`
+      await updateVirtuoso(`
         PREFIX prov: <http://www.w3.org/ns/prov#>
         PREFIX besluitvorming: <https://data.vlaanderen.be/ns/besluitvorming#>
         PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
@@ -327,7 +328,7 @@ async function insertPublicAgendaitems(kaleidosAgendaitems, publicAgenda, public
 }
 
 async function getNewsitem(kaleidosNewsitem, kaleidosAgendaitem) {
-  const newsitems = parseResult(await query(`
+  const newsitems = parseResult(await querySudo(`
     PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
     PREFIX prov: <http://www.w3.org/ns/prov#>
     PREFIX dct: <http://purl.org/dc/terms/>
@@ -349,7 +350,7 @@ async function getNewsitem(kaleidosNewsitem, kaleidosAgendaitem) {
   if (newsitem) {
     newsitem.uri = kaleidosNewsitem;
 
-    newsitem.themes = parseResult(await query(`
+    newsitem.themes = parseResult(await querySudo(`
       PREFIX dct: <http://purl.org/dc/terms/>
 
       SELECT ?uri
@@ -360,7 +361,7 @@ async function getNewsitem(kaleidosNewsitem, kaleidosAgendaitem) {
       }
     `));
 
-    newsitem.mandatees = parseResult(await query(`
+    newsitem.mandatees = parseResult(await querySudo(`
       PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
       PREFIX besluitvorming: <https://data.vlaanderen.be/ns/besluitvorming#>
       PREFIX prov: <http://www.w3.org/ns/prov#>
@@ -405,7 +406,7 @@ async function insertNewsitem(newsitem, graph) {
   if (newsitem.mandatees.length)
     optionalStatements.push(...newsitem.mandatees.map(mandatee => `<${newsitem.uri}> prov:qualifiedAssociation ${sparqlEscapeUri(mandatee.uri)} .`));
 
-  await update(`
+  await updateVirtuoso(`
       PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
       PREFIX prov: <http://www.w3.org/ns/prov#>
       PREFIX dct: <http://purl.org/dc/terms/>
@@ -428,12 +429,12 @@ async function insertNewsitem(newsitem, graph) {
 }
 
 async function getPublicDocuments(kaleidosNewsitem, kaleidosAgendaitem) {
-  return parseResult(await query(`
+  return parseResult(await querySudo(`
     PREFIX besluitvorming: <https://data.vlaanderen.be/ns/besluitvorming#>
     PREFIX prov: <http://www.w3.org/ns/prov#>
     PREFIX dct: <http://purl.org/dc/terms/>
 
-    SELECT ?piece AS ?uri
+    SELECT (?piece AS ?uri)
     WHERE {
       GRAPH ${sparqlEscapeUri(config.kaleidos.graphs.kanselarij)} {
         <${kaleidosNewsitem}> prov:wasDerivedFrom ?agendaitemTreatment .
@@ -525,7 +526,7 @@ async function insertDocuments(kaleidosPieces, agendaitem, graph) {
     }`, graph);
 
     // Link pieces to newsitem
-    await update(`
+    await updateVirtuoso(`
       PREFIX prov: <http://www.w3.org/ns/prov#>
       PREFIX besluitvorming: <https://data.vlaanderen.be/ns/besluitvorming#>
 


### PR DESCRIPTION
Adds some small general improvements to the export service.

- Perform (sudo) queries through mu-auth instead of directly to Virtuoso where applicable
  - Updates are still sent directly to Virtuoso so as to not generate deltas
  - This should in make the queries somewhat more stable to random Virtuoso downtime (e.g. during checkpoints)
- Use Virtuoso specific optimization for `DROP GRAPH` query
- Add `ORDER BY`, `LIMIT`, and `OFFSET` to the `CONSTRUCT` call inside an inner query

https://kanselarij.atlassian.net/browse/KAS-4094