### PR TITLE
fix: also link piece to derived file if inserting

### DIFF
--- a/support/sparql-queries.js
+++ b/support/sparql-queries.js
@@ -552,6 +552,7 @@ async function insertDocuments(kaleidosPieces, agendaitem, graph) {
     PREFIX dct: <http://purl.org/dc/terms/>
 
     CONSTRUCT {
+      ${sparqlEscapeUri(piece.uri)} prov:value ?derivedFile .
       ?derivedFile a nfo:FileDataObject ;
         mu:uuid ?uuidDerivedFile ;
         nfo:fileName ?fileNameDerivedFile ;


### PR DESCRIPTION
When we insert the source file (because there's no derived file) we should still link it to the piece otherwise Themis & Valvas break.