### PR TITLE
KAS-4883 refactor job status uri, predicates, update js-template

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM semtech/mu-javascript-template:1.5.0-beta.4
+FROM semtech/mu-javascript-template:1.8.0
 LABEL maintainer="info@redpencil.io"
 
+#ignore SecretsUsedInArgOrEnv, not sensitive data
 ENV DEBUG_AUTH_HEADERS="false"

--- a/README.md
+++ b/README.md
@@ -57,10 +57,10 @@ Resource representing an export job. Jobs are executed one by one using the FIFO
 
 #### Export job statuses
 The status of the export job will be updated to reflect the progress of the job. The following statuses are known:
-* http://data.kaleidos.vlaanderen.be/public-export-job-statuses/scheduled
-* http://data.kaleidos.vlaanderen.be/public-export-job-statuses/ongoing
-* http://data.kaleidos.vlaanderen.be/public-export-job-statuses/success
-* http://data.kaleidos.vlaanderen.be/public-export-job-statuses/failure
+* http://redpencil.data.gift/id/concept/JobStatus/scheduled
+* http://redpencil.data.gift/id/concept/JobStatus/busy
+* http://redpencil.data.gift/id/concept/JobStatus/success
+* http://redpencil.data.gift/id/concept/JobStatus/failed
 
 #### Themis publication activity
 Resource respresenting a planned publication for a meeting. This resource resides in the Kaleidos DB.

--- a/config.js
+++ b/config.js
@@ -25,12 +25,13 @@ export default {
     },
     job: {
       statuses: {
-        scheduled: 'http://data.kaleidos.vlaanderen.be/public-export-job-statuses/scheduled',
-        ongoing: 'http://data.kaleidos.vlaanderen.be/public-export-job-statuses/ongoing',
-        success: 'http://data.kaleidos.vlaanderen.be/public-export-job-statuses/success',
-        failure: 'http://data.kaleidos.vlaanderen.be/public-export-job-statuses/failure'
+        scheduled: 'http://redpencil.data.gift/id/concept/JobStatus/scheduled',
+        busy: 'http://redpencil.data.gift/id/concept/JobStatus/busy',
+        success: 'http://redpencil.data.gift/id/concept/JobStatus/success',
+        failed: 'http://redpencil.data.gift/id/concept/JobStatus/failed'
       },
       maxRetryCount: 5,
+      rdfType: 'http://mu.semte.ch/vocabularies/ext/PublicExportJob'
     },
     resourceUri: {
       public: function(type, id) { return `http://themis.vlaanderen.be/id/${type}/${id}`; }

--- a/support/jobs.js
+++ b/support/jobs.js
@@ -210,8 +210,8 @@ async function updateJobStatus(uri, status, errorMessage) {
     timePred = 'http://www.w3.org/ns/prov#startedAtTime';
   }
   await update(`
-  PREFIX dct: <http://purl.org/dc/terms/>
   PREFIX adms: <http://www.w3.org/ns/adms#>
+  PREFIX schema: <http://schema.org/>
 
   DELETE {
     GRAPH <${config.export.graphs.job}> {

--- a/support/jobs.js
+++ b/support/jobs.js
@@ -181,12 +181,10 @@ async function executeJob(job) {
     await updateJobStatus(job.uri, config.export.job.statuses.success);
     console.log(`Successfully finished job <${job.uri}>`);
   } catch (e) {
-    console.log(
-      `Execution of job <${job.uri}> failed [tries: ${job.retryCount + 1}/${config.export.job.maxRetryCount}]: ${e}`
-    );
+    const errorMessage = `Execution of job <${job.uri}> failed [tries: ${job.retryCount + 1}/${config.export.job.maxRetryCount}]: ${e?.message}`;
+    console.log(errorMessage);
     console.trace(e);
-    // TODO message on fail? we could check this in frontend maybe?
-    await updateJobStatus(job.uri, config.export.job.statuses.failed);
+    await updateJobStatus(job.uri, config.export.job.statuses.failed, errorMessage);
     await incrementJobRetryCount(job.uri, job.retryCount);
   }
 }

--- a/support/jobs.js
+++ b/support/jobs.js
@@ -60,12 +60,11 @@ async function createJob(meeting, scopes, source = null) {
 
   INSERT DATA {
     GRAPH <${config.export.graphs.job}> {
-        ${sparqlEscapeUri(jobUri)} a ext:PublicExportJob ;
+        ${sparqlEscapeUri(jobUri)} a ${sparqlEscapeUri(config.export.job.rdfType)} ;
                            mu:uuid ${sparqlEscapeString(jobUuid)} ;
                            prov:used ${sparqlEscapeUri(meeting)} ;
                            adms:status ${sparqlEscapeUri(config.export.job.statuses.scheduled)} ;
-                           dct:created ${sparqlEscapeDateTime(now)} ;
-                           dct:modified ${sparqlEscapeDateTime(now)} .
+                           dct:created ${sparqlEscapeDateTime(now)} .
         ${scopeStatements.join('\n')}
         ${sourceStatement}
     }
@@ -90,9 +89,9 @@ async function getNextScheduledJob() {
     GRAPH <${config.export.graphs.job}> {
       VALUES ?status {
         ${sparqlEscapeUri(config.export.job.statuses.scheduled)}
-        ${sparqlEscapeUri(config.export.job.statuses.failure)}
+        ${sparqlEscapeUri(config.export.job.statuses.failed)}
       }
-      ?uri a ext:PublicExportJob ;
+      ?uri a ${sparqlEscapeUri(config.export.job.rdfType)} ;
            mu:uuid ?id ;
            dct:created ?created ;
            prov:used ?meeting ;
@@ -101,8 +100,8 @@ async function getNextScheduledJob() {
       BIND(IF(BOUND(?maybeRetryCount), ?maybeRetryCount, 0) AS ?retryCount)
       FILTER (?retryCount < ${sparqlEscapeInt(config.export.job.maxRetryCount)})
       FILTER NOT EXISTS {
-        ?job a ext:PublicExportJob ;
-           adms:status ${sparqlEscapeUri(config.export.job.statuses.ongoing)} .
+        ?job a ${sparqlEscapeUri(config.export.job.rdfType)} ;
+           adms:status ${sparqlEscapeUri(config.export.job.statuses.busy)} .
       }
     }
   } ORDER BY ASC(?created) LIMIT 1`);
@@ -131,7 +130,7 @@ async function getJob(uuid) {
   SELECT ?uri ?created ?meeting ?status
   WHERE {
     GRAPH <${config.export.graphs.job}> {
-      ?uri a ext:PublicExportJob ;
+      ?uri a ${sparqlEscapeUri(config.export.job.rdfType)} ;
            mu:uuid ${sparqlEscapeString(uuid)} ;
            dct:created ?created ;
            prov:used ?meeting ;
@@ -155,7 +154,7 @@ async function getJob(uuid) {
 
 async function executeJob(job) {
   try {
-    await updateJobStatus(job.uri, config.export.job.statuses.ongoing);
+    await updateJobStatus(job.uri, config.export.job.statuses.busy);
     const result = await query(`
     PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
 
@@ -186,31 +185,47 @@ async function executeJob(job) {
       `Execution of job <${job.uri}> failed [tries: ${job.retryCount + 1}/${config.export.job.maxRetryCount}]: ${e}`
     );
     console.trace(e);
-    await updateJobStatus(job.uri, config.export.job.statuses.failure);
+    // TODO message on fail? we could check this in frontend maybe?
+    await updateJobStatus(job.uri, config.export.job.statuses.failed);
     await incrementJobRetryCount(job.uri, job.retryCount);
   }
 }
 
 async function getSummary() {
   const result = await query(`
+    PREFIX adms: <http://www.w3.org/ns/adms#>
+
     SELECT ?status (COUNT(?s) as ?count) WHERE {
-      GRAPH <http://mu.semte.ch/graphs/kaleidos-export> {
-        ?s a <http://mu.semte.ch/vocabularies/ext/PublicExportJob> ;  <http://www.w3.org/ns/adms#status> ?status .
+      GRAPH <${config.export.graphs.job}> {
+        ?s a ${sparqlEscapeUri(config.export.job.rdfType)} ;  adms:status ?status .
       }
     } GROUP BY ?status`);
 
   return result.results.bindings.map(b => { return { status: b['status'].value, count: parseInt(b['count'].value) }; });
 }
 
-async function updateJobStatus(uri, status) {
+async function updateJobStatus(uri, status, errorMessage) {
+  let timePred;
+  if (status === JOB.STATUSES.SUCCESS || status === JOB.STATUSES.FAILED) {
+    timePred = 'http://www.w3.org/ns/prov#endedAtTime';
+  } else {
+    timePred = 'http://www.w3.org/ns/prov#startedAtTime';
+  }
   await update(`
   PREFIX dct: <http://purl.org/dc/terms/>
   PREFIX adms: <http://www.w3.org/ns/adms#>
 
-  DELETE WHERE {
+  DELETE {
     GRAPH <${config.export.graphs.job}> {
-        ${sparqlEscapeUri(uri)} dct:modified ?modified ;
-             adms:status ?status.
+      ${sparqlEscapeUri(uri)} adms:status ?status .
+      ${sparqlEscapeUri(uri)} ${sparqlEscapeUri(timePred)} ?time .
+    }
+  } WHERE {
+    GRAPH <${config.export.graphs.job}> {
+      ${sparqlEscapeUri(uri)} adms:status ?status .
+      OPTIONAL {
+        ${sparqlEscapeUri(uri)} ${sparqlEscapeUri(timePred)} ?time .
+      }
     }
   }
 
@@ -218,7 +233,8 @@ async function updateJobStatus(uri, status) {
 
   INSERT DATA {
     GRAPH <${config.export.graphs.job}> {
-        ${sparqlEscapeUri(uri)} dct:modified ${sparqlEscapeDateTime(new Date())};
+        ${sparqlEscapeUri(uri)} ${sparqlEscapeUri(timePred)} ${sparqlEscapeDateTime(new Date())} ;
+        ${errorMessage ? `schema:error ${sparqlEscapeString(errorMessage)} ;` : ""}
              adms:status ${sparqlEscapeUri(status)}.
     }
   }`);

--- a/support/polling.js
+++ b/support/polling.js
@@ -45,7 +45,7 @@ async function getRecentPublicationActivities() {
         ?meeting mu:uuid ?meetingId .
       }
       GRAPH ${sparqlEscapeUri(config.export.graphs.job)} {
-        FILTER NOT EXISTS { ?job a ext:PublicExportJob ; dct:source ?uri }
+        FILTER NOT EXISTS { ?job a ${sparqlEscapeUri(config.export.job.rdfType)} ; dct:source ?uri }
       }
     } ORDER BY ?plannedStart
   `);

--- a/support/query-helpers.js
+++ b/support/query-helpers.js
@@ -49,7 +49,7 @@ async function copyToLocalGraph(query, graph) {
     }
   } catch (e) {
     console.log(`Something went wrong while executing query: ${query}. Nothing inserted in the store.`);
-    console.log(e);
+    console.trace(e);
     throw e;
   }
 }


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-4883

- use redpencil statuses instead of job specific statuses
- refactor `dct:modified` to `prov:startedAtTime` (on change to busy) and `prov:endedAtTime`  (on success or fail)
- added `schema:error` on fail
- bumped js-template
- extracted rdf type of job to config



note: can't assign `cogs:Job` because of graph contraints (the job could then be created in both kanselarij graph and themis graph)