### PR TITLE
KAS-5099 make agendaActivity optional for publication

### DIFF
--- a/support/sparql-queries.js
+++ b/support/sparql-queries.js
@@ -373,9 +373,14 @@ async function getNewsitem(kaleidosNewsitem, kaleidosAgendaitem) {
         GRAPH ${sparqlEscapeUri(config.kaleidos.graphs.kanselarij)} {
           <${kaleidosNewsitem}> prov:wasDerivedFrom ?agendaitemTreatment .
           ?agendaitemTreatment dct:subject <${kaleidosAgendaitem}> .
-          ?agendaActivity besluitvorming:genereertAgendapunt <${kaleidosAgendaitem}> ;
-                          besluitvorming:vindtPlaatsTijdens ?subcase .
-          ?subcase ext:heeftBevoegde ?uri .
+          OPTIONAL {
+            # legacy data may not have agendaActivity or subcase
+            ?agendaActivity besluitvorming:genereertAgendapunt <${kaleidosAgendaitem}> ;
+                            besluitvorming:vindtPlaatsTijdens ?subcase .
+            ?subcase ext:heeftBevoegde ?subcaseMandateesUri .
+          }
+          <${kaleidosAgendaitem}> ext:heeftBevoegdeVoorAgendapunt ?agendaitemMandateesUri .
+          BIND(COALESCE(?subcaseMandateesUri , ?agendaitemMandateesUri) AS ?uri)
         }
         GRAPH ${sparqlEscapeUri(config.kaleidos.graphs.public)} {
           OPTIONAL {
@@ -439,7 +444,7 @@ async function getPublicDocuments(kaleidosNewsitem, kaleidosAgendaitem) {
       GRAPH ${sparqlEscapeUri(config.kaleidos.graphs.kanselarij)} {
         <${kaleidosNewsitem}> prov:wasDerivedFrom ?agendaitemTreatment .
         ?agendaitemTreatment dct:subject <${kaleidosAgendaitem}> .
-        ?agendaActivity besluitvorming:genereertAgendapunt <${kaleidosAgendaitem}> .
+        OPTIONAL { ?agendaActivity besluitvorming:genereertAgendapunt <${kaleidosAgendaitem}> . } # legacy may not have agendaActivity
         <${kaleidosAgendaitem}> besluitvorming:geagendeerdStuk ?piece .
         ?piece besluitvorming:vertrouwelijkheidsniveau <${config.kaleidos.accessLevels.public}> .
       }


### PR DESCRIPTION
https://kanselarij.atlassian.net/browse/KAS-5099

- make `agendaActivity` optional for docs (should we just remove it from the document query? doesn't add any value unless we add a date check - optional only if date < some date ?
- make `agendaActivity/subcase` optional for mandatees (this made sense, announcement without subcase can still have mandatees but not showing on webplatform)
 